### PR TITLE
Include "EuregJUG" in registration mail subject

### DIFF
--- a/src/main/resources/messages_de.properties
+++ b/src/main/resources/messages_de.properties
@@ -76,7 +76,7 @@ Hallo {0},<br />\
 Du hast Dich erfolgreich zur Veranstaltung "{1}" am {2,date,medium} angemeldet. \
 Die EuregJUG freut sich sehr auf Dein Kommen.<br /><br />\
 Herzliche Gr\u00fc\u00dfe aus Aachen!
-registrationConfirmationSubject = Best\u00e4tigung der Anmeldung zu "{0}"
+registrationConfirmationSubject = Best\u00e4tigung der Anmeldung zur EuregJUG Veranstaltung "{0}"
 registerHere = Hier anmelden
 reset = Zur\u00fccksetzen
 search = Suchen

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -75,7 +75,7 @@ Hello {0},<br />\
 You have registered successfully for "{1}" on {2,date,medium}. \
 The EuregJUG is looking forward to meet you.<br /><br />\
 Best regards from Aachen
-registrationConfirmationSubject = Confirmation of your registration for "{0}"
+registrationConfirmationSubject = Confirmation of your registration for EuregJUG event "{0}"
 registerHere = Register here
 reset = Reset
 sponsors = Thanks to


### PR DESCRIPTION
I noticed I had trouble finding confirmation mails for the talks I already registered to.
I think having the name "EuregJUG" in the mail subject would make it a bit clearer.